### PR TITLE
SES-1598: Bump CMake version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(bluetooth_pair)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
Mass Bump anywhere we set `cmake_minimum_required`

Full build ran across all repos that have changed.

Mentions SES-1598